### PR TITLE
fix: tabs on consultation page

### DIFF
--- a/laconsultation.html
+++ b/laconsultation.html
@@ -215,4 +215,4 @@ additional_css: laconsultation
 
 </section>
 
-<script type="null">  $('#bonnes-pratiques .menu .item').tab();</script>
+<script type="text/javascript">  $('#bonnes-pratiques .menu .item').tab();</script>


### PR DESCRIPTION
The script tag had a 'null' type, probably set by forestry when generating the page because the tag did not specify a type, causing javascript in this tag to not run.
Changed to 'type/javascript'.